### PR TITLE
feat: send donor message

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -39,24 +39,12 @@
             </v-row>
             <v-row>
               <v-col>
-                <table v-if="donors">
-                  <thead>
-                    <tr>
-                      <th class="text-left">Name</th>
-                      <th class="text-left">Email</th>
-                      <th class="text-left">Total Donations</th>
-                      <th class="text-left">First Donation</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr v-for="item in donors.data" :key="item.id">
-                      <td>{{ item.full_name }}</td>
-                      <td>{{ item.email }}</td>
-                      <td>{{ item.total_donations }}</td>
-                      <td>{{ item.first_donation }}</td>
-                    </tr>
-                  </tbody>
-                </table>
+                <app-table
+                  :items="donors?.data || []"
+                  :loading="donorListLoading"
+                  :headers="headers"
+                > 
+                </app-table>
               </v-col>
             </v-row>
           </v-container>
@@ -118,13 +106,23 @@
 </template>
 
 <script>
-import axios from "axios";
+import { mapGetters } from 'vuex'
+import AppTable from './components/AppTable/AppTable.vue';
+
 export default {
   name: "App",
 
+  components: {
+    AppTable,
+  },
   data() {
     return {
-      donors: null,
+      headers: [
+        { text: 'Name', value: 'full_name' },
+        { text: 'Email', value: 'email' },
+        { text: 'Total Donations', value: 'total_donations' },
+        { text: 'First Donation', value: 'first_donation' },
+      ],
       valid: false,
       email: "",
       donor_id: "",
@@ -146,14 +144,21 @@ export default {
     };
   },
   mounted() {
-    axios
-      .get("https://interview.ribbon.giving/api/donors")
-      .then((response) => (this.donors = response.data));
+    this.fetchDonors();
   },
   methods: {
+    async fetchDonors() {
+      this.$store.dispatch('donorListAction');
+    },
     async submit() {
       // Send message to server.
     },
+  },
+  computed: {
+    ...mapGetters({
+      donors: 'donors',
+      donorListLoading: 'donorListLoading'
+    }),
   },
 };
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,8 @@
       </v-container>
     </v-app-bar>
 
+    <Snackbar />
+
     <v-main>
       <section id="hero">
         <v-sheet class="d-flex align-center pb-16" color="grey-darken-3">
@@ -65,27 +67,11 @@
                 </v-responsive>
               </v-col>
               <v-sheet width="400" class="mx-auto">
-                <v-form
-                  v-model="valid"
-                  validate-on="submit"
-                  @submit.prevent="submit"
+                <app-form
+                  :items="donors?.data"
+                  :loading="donorListLoading"
                 >
-                  <v-textarea
-                    v-model="message"
-                    :rules="messageRules"
-                    label="Message"
-                  ></v-textarea>
-                  <v-text-field
-                    v-model="email"
-                    :rules="emailRules"
-                    label="Email"
-                  ></v-text-field>
-                  <v-text-field
-                    v-model="donor_id"
-                    label="Donor Id"
-                  ></v-text-field>
-                  <v-btn type="submit" block class="mt-2">Send</v-btn>
-                </v-form>
+                </app-form>
               </v-sheet>
             </v-row>
           </v-container>
@@ -108,12 +94,16 @@
 <script>
 import { mapGetters } from 'vuex'
 import AppTable from './components/AppTable/AppTable.vue';
+import AppForm from './components/Form/AppForm.vue';
+import Snackbar from './components/Snackbar/Snackbar.vue';
 
 export default {
   name: "App",
 
   components: {
     AppTable,
+    AppForm,
+    Snackbar
   },
   data() {
     return {
@@ -123,24 +113,6 @@ export default {
         { text: 'Total Donations', value: 'total_donations' },
         { text: 'First Donation', value: 'first_donation' },
       ],
-      valid: false,
-      email: "",
-      donor_id: "",
-      message: "",
-      emailRules: [
-        (value) => {
-          if (value) return true;
-
-          return "E-mail is required.";
-        },
-      ],
-      messageRules: [
-        (value) => {
-          if (value) return true;
-
-          return "Message is required.";
-        },
-      ],
     };
   },
   mounted() {
@@ -149,9 +121,6 @@ export default {
   methods: {
     async fetchDonors() {
       this.$store.dispatch('donorListAction');
-    },
-    async submit() {
-      // Send message to server.
     },
   },
   computed: {

--- a/src/components/AppTable/AppTable.vue
+++ b/src/components/AppTable/AppTable.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <v-text-field v-model="search" label="Search" dense outlined />
+      <v-data-table
+        :headers="headers"
+        :items="filteredItems"
+        :sort-by.sync="sortBy"
+        :sort-desc.sync="sortDesc"
+        :loading="loading"
+        class="custom-header"
+      >
+      <template v-slot:item.total_donations="{ item }">
+        {{ formatCurrency(item.total_donations) }}
+      </template>
+      <template v-slot:item.first_donation="{ item }">
+        {{ formatDate(item.first_donation) }}
+      </template>
+    </v-data-table>
+  </div>
+</template>
+
+<script>
+  export default {
+    props: [
+      'headers',
+      'items',
+      'loading',
+    ],
+    data () {
+      return {
+        search: '',
+        sortBy: 'fat',
+        sortDesc: false,
+      }
+    },
+    computed: {
+      filteredItems() {
+        return this.items.filter((donor) =>
+          Object.values(donor).some(
+            (fieldValue) =>
+              fieldValue &&
+              fieldValue
+                .toString()
+                .toLowerCase()
+                .includes(this.search.toLowerCase())
+          )
+        );
+      },
+    },
+    methods: {
+      formatCurrency(amount) {
+        const formatter = new Intl.NumberFormat('en-US', {
+          style: 'currency',
+          currency: 'USD',
+        });
+        return formatter.format(amount);
+      },
+      formatDate(date) {
+        const options = { year: 'numeric', month: 'short', day: 'numeric' };
+        return new Date(date).toLocaleDateString(undefined, options);
+      },
+    },
+  }
+</script>
+<style lang="scss">
+  @import './styles.scss';
+</style>

--- a/src/components/AppTable/AppTable.vue
+++ b/src/components/AppTable/AppTable.vue
@@ -29,7 +29,7 @@
     data () {
       return {
         search: '',
-        sortBy: 'fat',
+        sortBy: 'full_name',
         sortDesc: false,
       }
     },

--- a/src/components/AppTable/AppTable.vue
+++ b/src/components/AppTable/AppTable.vue
@@ -1,14 +1,15 @@
 <template>
   <div>
     <v-text-field v-model="search" label="Search" dense outlined />
-      <v-data-table
-        :headers="headers"
-        :items="filteredItems"
-        :sort-by.sync="sortBy"
-        :sort-desc.sync="sortDesc"
-        :loading="loading"
-        class="custom-header"
-      >
+    <v-data-table
+      :headers="headers"
+      :items="items"
+      :search="search"
+      :sort-by.sync="sortBy"
+      :sort-desc.sync="sortDesc"
+      :loading="loading"
+      class="custom-header"
+    >
       <template v-slot:item.total_donations="{ item }">
         {{ formatCurrency(item.total_donations) }}
       </template>
@@ -32,20 +33,6 @@
         sortBy: 'full_name',
         sortDesc: false,
       }
-    },
-    computed: {
-      filteredItems() {
-        return this.items.filter((donor) =>
-          Object.values(donor).some(
-            (fieldValue) =>
-              fieldValue &&
-              fieldValue
-                .toString()
-                .toLowerCase()
-                .includes(this.search.toLowerCase())
-          )
-        );
-      },
     },
     methods: {
       formatCurrency(amount) {

--- a/src/components/AppTable/styles.scss
+++ b/src/components/AppTable/styles.scss
@@ -1,0 +1,13 @@
+.custom-header {
+  color: #3a3a40de !important;
+
+  .v-data-table-header {
+    background-color: #3a3a400d;
+  }
+
+  tbody {
+    tr:hover {
+      background-color: #3a3a404d !important;
+    }
+  }
+}

--- a/src/components/Form/AppForm.vue
+++ b/src/components/Form/AppForm.vue
@@ -1,0 +1,90 @@
+<template>
+  <v-form
+    v-model="valid"
+    validate-on="submit"
+    @submit.prevent="submit"
+  >
+    <v-textarea
+      v-model="form.message"
+      :rules="messageRules"
+      label="Message"
+      @change="updateFormField('message', $event)"
+    ></v-textarea>
+    <v-autocomplete
+      label="Search for email"
+      v-model="form.email"
+      :items="items"
+      :loading="loading"
+      item-text="email"
+      item-value="id"
+      return-object
+      @change="updateFormField('email', $event)"
+    >
+    </v-autocomplete>
+    <v-text-field
+      v-model="form.donor_id"
+      label="Donor Id"
+      readonly
+    ></v-text-field>
+    <v-btn
+      type="submit"
+      block
+      class="mt-2"
+      :disabled="!valid || sendingMessageLoading || !form.donor_id"
+    >
+      Send
+    </v-btn>
+  </v-form>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+export default {
+  props: [
+    'items',
+    'loading',
+  ],
+  name: "App",
+  data() {
+    return {
+      valid: false,
+      form: {
+        message: "",
+        email: "",
+        donor_id: "",
+      },
+      emailRules: [
+        (value) => !!value || "Email is required.",
+      ],
+      messageRules: [
+        (value) => !!value || 'Message is required',
+        (value) => (value && value.length >= 15) || 'Message must be at least 15 characters',
+      ],
+    };
+  },
+  methods: {
+    async submit() {
+      const formData = new FormData();
+      formData.append("email", this.form.email);
+      formData.append("donor_id", this.form.donor_id);
+      formData.append("message", this.form.message);
+      await this.$store.dispatch('sendDonorMessageAction', { formData });
+      this.form.message = '';
+      this.form.email = '';
+      this.form.donor_id = '';
+    },
+    updateFormField(field, event) {
+      this.form[field] = event;
+      if (field === 'email') {
+        this.form['donor_id'] = event.id;
+      }
+    }
+  },
+  computed: {
+    ...mapGetters({
+      sendingMessageLoading: 'sendingMessageLoading'
+    }),
+  },
+};
+</script>

--- a/src/components/Snackbar/Snackbar.vue
+++ b/src/components/Snackbar/Snackbar.vue
@@ -1,0 +1,43 @@
+<template>
+  <v-snackbar
+    v-model="openSnackbar"
+    timeout="2000"
+    :color="snackVariant"
+    variant="tonal"
+    @input="onSnackbarInput"
+  >
+    {{ snackMessage }}
+  </v-snackbar>
+</template>
+
+<script>
+import { mapGetters } from 'vuex';
+
+export default {
+  name: 'Snackbar',
+  computed: {
+    ...mapGetters({
+      sendSnackMessage: 'sendSnackMessage',
+    }),
+    openSnackbar: {
+      get() {
+        return this.sendSnackMessage.show;
+      },
+      set() {
+        this.$store.dispatch('resetDonorMessageAction');
+      }
+    },
+    snackVariant() {
+      return this.sendSnackMessage.variant;
+    },
+    snackMessage() {
+      return this.sendSnackMessage.message;
+    },
+  },
+  methods: {
+    onSnackbarInput(value) {
+      this.$store.dispatch('resetDonorMessageAction');
+    }
+  },
+}
+</script>

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -4,4 +4,11 @@ import Vuetify from 'vuetify/lib/framework';
 Vue.use(Vuetify);
 
 export default new Vuetify({
+  theme: {
+    themes: {
+      light: {
+        primary: '#00754A',
+      },
+    },
+  },
 });

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,0 +1,5 @@
+import appActions from './modules/app/actions';
+
+export default {
+  ...appActions,
+}

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -1,0 +1,5 @@
+import appGetter from './modules/app/getters';
+
+export default {
+  ...appGetter
+};

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,12 +1,17 @@
 import Vue from "vue";
 import Vuex from "vuex";
-// import { state } from "./state";
-// import * as getters from "./getters";
-// import * as actions from "./actions";
-// import * as mutations from "./mutations";
+import state from "./state";
+import actions from "./actions";
+import getters from "./getters";
+import mutations from "./mutations";
 
 Vue.use(Vuex);
 
-const store = new Vuex.Store({});
+const store = new Vuex.Store({
+  state,
+  actions,
+  getters,
+  mutations,
+});
 
 export default store;

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -13,7 +13,46 @@ const actions = {
       console.log(error);
       context.commit('donorListLoading', false);
     }
-  }
+  },
+
+  resetDonorMessageAction(context) {
+    context.commit('sendSnackMessage', {
+      show: false,
+      variant: '',
+      message: ''
+    });
+  },
+
+  async sendDonorMessageAction(context, payload) {
+    const { formData } = payload;
+    const donorId = formData.get('donor_id');
+
+    try {
+      context.commit('sendingMessageLoading', true);
+      await axios.post(
+        `https://interview.ribbon.giving/api/donors/${donorId}/send-message`,
+        formData,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          }
+        }
+      );
+      context.commit('sendingMessageLoading', false);
+      context.commit('sendSnackMessage', {
+        show: true,
+        variant: 'success',
+        message: 'Thankyou for your message. It has been sent.'
+      });
+    } catch (e) {
+      context.commit('sendingMessageLoading', false);
+      context.commit('sendSnackMessage', {
+        show: true,
+        variant: 'red',
+        message: 'There was an error trying to sending your message. Please try again later'
+      });
+    }
+  },
 };
 
 export default actions;

--- a/src/store/modules/app/actions.js
+++ b/src/store/modules/app/actions.js
@@ -1,0 +1,19 @@
+import axios from "axios";
+
+const actions = {
+  async donorListAction(context) {
+    try {
+      context.commit('donorListLoading', true);
+      const response = await axios.get(
+        'https://interview.ribbon.giving/api/donors'
+      );
+      context.commit('donorList', response.data);
+      context.commit('donorListLoading', false);
+    } catch (e) {
+      console.log(error);
+      context.commit('donorListLoading', false);
+    }
+  }
+};
+
+export default actions;

--- a/src/store/modules/app/getters.js
+++ b/src/store/modules/app/getters.js
@@ -1,6 +1,9 @@
 const getters = {
   donors: state => state.app.donors,
   donorListLoading: state => state.app.donorListLoading,
+  sendingMessageLoading: state => state.app.sendingMessageLoading,
+  sendSnackMessage: state => state.app.sendSnackMessage,
+  showSnackbar: state => state.app.sendSnackMessage.show,
 };
 
 export default getters;

--- a/src/store/modules/app/getters.js
+++ b/src/store/modules/app/getters.js
@@ -1,0 +1,6 @@
+const getters = {
+  donors: state => state.app.donors,
+  donorListLoading: state => state.app.donorListLoading,
+};
+
+export default getters;

--- a/src/store/modules/app/mutations.js
+++ b/src/store/modules/app/mutations.js
@@ -5,6 +5,12 @@ const mutations = {
   donorListLoading (state, payload) {
     state.app.donorListLoading = payload;
   },
+  sendingMessageLoading(state, payload) {
+    state.app.sendingMessageLoading = payload;
+  },
+  sendSnackMessage(state, payload) {
+    state.app.sendSnackMessage = payload;
+  }
 };
 
 export default mutations;

--- a/src/store/modules/app/mutations.js
+++ b/src/store/modules/app/mutations.js
@@ -1,0 +1,10 @@
+const mutations = {
+  donorList (state, payload) {
+    state.app.donors = payload;
+  },
+  donorListLoading (state, payload) {
+    state.app.donorListLoading = payload;
+  },
+};
+
+export default mutations;

--- a/src/store/modules/app/state.js
+++ b/src/store/modules/app/state.js
@@ -1,0 +1,6 @@
+export default {
+  app: {
+    donors: null,
+    donorListLoading: false,
+  },
+};

--- a/src/store/modules/app/state.js
+++ b/src/store/modules/app/state.js
@@ -2,5 +2,11 @@ export default {
   app: {
     donors: null,
     donorListLoading: false,
+    sendingMessageLoading: false,
+    sendSnackMessage: {
+      show: false,
+      variant: '',
+      message: '',
+    },
   },
 };

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -1,0 +1,5 @@
+import appMutations from './modules/app/mutations';
+
+export default {
+  ...appMutations,
+};

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -1,0 +1,7 @@
+import appState from './modules/app/state';
+
+const state = {
+  ...appState,
+}
+
+export default state;


### PR DESCRIPTION
# Description

Send Donor message

Fixes # (issue)
https://github.com/roundupapp/ribbon-interview-vue/issues/4

# Checklist:

- [ ] The form should include some vuetify search and select feature for when they type in the email. This way we have the proper donor id.
- [ ] The form should hit the endpoint https://interview.ribbon.giving/api/donors/{donor_id}/send-message with a post request.
- [ ] Headers should include Accept and Content-type = 'application/json'
- [ ] The message should have validation on the front end to be greater than 15 characters.
- [ ] Please show some success alert and clear the form afterwards.
- [ ] Handle any errors gracefully. (Add Snackbar component)